### PR TITLE
Add HTTP header for discoverability

### DIFF
--- a/aperture.php
+++ b/aperture.php
@@ -17,6 +17,7 @@ class Aperture_Plugin {
   public function __construct() {
     #add_action( 'register_activation_hook', array( $this, 'register_activation_hook' ) );
     register_activation_hook( __FILE__, array( $this, 'activated' ) );
+    add_action( 'send_headers', array( $this, 'http_header' ) );
     add_action( 'wp_head', array( $this, 'html_header' ) );
     add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 
@@ -127,6 +128,12 @@ class Aperture_Plugin {
     </div>
     <?php
     delete_option( 'aperture_registration_success' );
+  }
+
+  public function http_header() {
+    if( $url = get_option('aperture_microsub_url') ) {
+      header( 'Link: <' . $url . '>; rel="microsub"', false );
+    }
   }
 
   public function html_header() {


### PR DESCRIPTION
Because [just talking](https://chat.indieweb.org/dev/2019-04-09/1554819579430100) doesn’t change the world, here is a quick PR.

The code is based on how [indieweb/wordpress-micropub](https://github.com/indieweb/wordpress-micropub) adds link headers. But maybe a more veteran WordPress developer like @dshanske could give it the once over before this gets merged.